### PR TITLE
Added Astro examples

### DIFF
--- a/bin/generate/index.mjs
+++ b/bin/generate/index.mjs
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 
-const fs = require('fs');
-const {program} = require('commander');
-const download = require('image-downloader');
-const TextToSVG = require('text-to-svg');
+import fs from 'node:fs';
+import { program } from 'commander';
+import download from 'image-downloader';
+import TextToSVG from 'text-to-svg';
 
 const DEFAULT_USERNAME = 'HendrikPrinsZA';
 
@@ -26,12 +26,12 @@ class MyStats {
   }
 
   images() {
-    const lastUpdated = (new Date()).toISOString().split('T')[0]
+    const lastUpdated = new Date().toISOString().split('T')[0];
 
     const endpoints = [
       {
         key: 'badge-last-updated',
-        url: `https://img.shields.io/static/v1?label=${encodeURIComponent('Last Updated')}&message=${encodeURIComponent(lastUpdated)}&color=lightgrey`
+        url: `https://img.shields.io/static/v1?label=${encodeURIComponent('Last Updated')}&message=${encodeURIComponent(lastUpdated)}&color=lightgrey`,
       },
       {
         key: 'github-stats',
@@ -44,63 +44,72 @@ class MyStats {
       {
         key: 'codersrank-stats',
         url: `https://cr-ss-service.azurewebsites.net/api/ScreenShot?widget=summary&branding=false&username=${this.username}&badges=3&show-avatar=false&style=--bg-color:%23292b3e;color:%231a1b27;--header-bg-color:%231a1b27;--header-text-color:%2370a4fc;--border-radius:0px;--badge-bg-color:%231a1b27;--badge-text-color:%2338bcad;`,
-        type: 'png'
+        type: 'png',
       },
       {
         key: 'codersrank-graph',
-        url: `https://cr-skills-chart-widget.azurewebsites.net/api/api?username=${this.username}&branding=false&bg=%23292b3e&style=--legend-text-color:%2338bcad;--label-font-weight=300;`
+        url: `https://cr-skills-chart-widget.azurewebsites.net/api/api?username=${this.username}&branding=false&bg=%23292b3e&style=--legend-text-color:%2338bcad;--label-font-weight=300;`,
       },
       {
         key: 'wakatime-last-30-days',
-        url: `https://github-readme-stats-taupe-two.vercel.app/api/wakatime?username=${this.username}&hide_title=true&hide_border=true&langs_count=10&theme=tokyonight&range=last_30_days&count_private=true&layout=compact&line_height=17`
+        url: `https://github-readme-stats-taupe-two.vercel.app/api/wakatime?username=${this.username}&hide_title=true&hide_border=true&langs_count=10&theme=tokyonight&range=last_30_days&count_private=true&layout=compact&line_height=17`,
       },
       {
         key: 'github-trophees',
-        url: `https://github-profile-trophy.vercel.app/?username=${this.username.toLowerCase()}&theme=tokyonight&no-frame=true&column=-1`
+        url: `https://github-profile-trophy.vercel.app/?username=${this.username.toLowerCase()}&theme=tokyonight&no-frame=true&column=-1`,
       },
       {
         key: 'codersrank-activity-chart',
         url: `https://cr-ss-service.azurewebsites.net/api/ScreenShot?widget=activity&username=${this.username}&branding=false&legend=true&tooltip=true&labels=true&style=--bg-color-0:%2338bcad;`,
-        type: 'png'
+        type: 'png',
       },
       {
         key: 'wakatime-custom-chart',
-        url: `https://wakatime.com/share/@${this.username}/c7782cc6-1009-47f4-a289-6061b219db66.svg`
-      }
+        url: `https://wakatime.com/share/@${this.username}/c7782cc6-1009-47f4-a289-6061b219db66.svg`,
+      },
     ];
 
-    endpoints.forEach((endpoint) => {
+    endpoints.forEach(endpoint => {
       const type = endpoint.type ?? 'svg';
       const rel = `../../../public/assets/generated/${endpoint.key}.${type}`;
       const dest = `../.${rel}`;
       const options = {
         url: endpoint.url,
-        dest: dest
+        dest: dest,
       };
-  
-      const debugLine = `- ${options.url}\n`;
-      download.image(options).then(() => {
-        console.log(`Saved image to '${options.dest}'`);
-        console.log(debugLine)
-      }).catch((err) => {
-        console.log(err);
-        const lines = [
-          `ERROR: Failed to generate image for ${options.dest}`,
-          debugLine
-        ];
-        console.log(lines.join("\n"));
 
-        // Fail softly, create placeholder image
-        const errorPath = `${rel}.error.svg`;
-        const textToSVG = TextToSVG.loadSync();
-        const attributes = {fill: 'red', stroke: 'black'};
-        const svgOptions = {x: 0, y: 0, fontSize: 24, anchor: 'top', attributes: attributes};
-        
-        const svg = textToSVG.getSVG(`Failed on "${endpoint.key}"`, svgOptions);
-        if (!fs.existsSync(errorPath)) {
-          fs.writeFileSync(errorPath, svg.toString(), { flag: 'w+' });
-        }
-      });
+      const debugLine = `- ${options.url}\n`;
+      download
+        .image(options)
+        .then(() => {
+          console.log(`Saved image to '${options.dest}'`);
+          console.log(debugLine);
+        })
+        .catch(err => {
+          console.log(err);
+          const lines = [
+            `ERROR: Failed to generate image for ${options.dest}`,
+            debugLine,
+          ];
+          console.log(lines.join('\n'));
+
+          // Fail softly, create placeholder image
+          const errorPath = `${rel}.error.svg`;
+          const textToSVG = TextToSVG.loadSync();
+          const attributes = { fill: 'red', stroke: 'black' };
+          const svgOptions = {
+            x: 0,
+            y: 0,
+            fontSize: 24,
+            anchor: 'top',
+            attributes: attributes,
+          };
+
+          const svg = textToSVG.getSVG(`Failed on "${endpoint.key}"`, svgOptions);
+          if (!fs.existsSync(errorPath)) {
+            fs.writeFileSync(errorPath, svg.toString(), { flag: 'w+' });
+          }
+        });
     });
   }
 }
@@ -112,7 +121,7 @@ program
 program
   .command('images')
   .description('Download profile images')
-  .action((action) => {
+  .action(action => {
     const opts = program.opts();
     const username = opts.username ?? DEFAULT_USERNAME;
     const myStats = new MyStats(username);

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prepare": "husky install",
     "lint": "eslint .",
     "style": "prettier --write . --plugin=prettier-plugin-astro && eslint . --fix",
-    "generate:images": "node bin/generate/index.js images"
+    "generate:images": "node bin/generate/index.mjs images"
   },
   "dependencies": {
     "@astrojs/check": "^0.9.9",

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -11,7 +11,8 @@ export interface Props {
     | "career"
     | "search"
     | "gallery"
-    | "projects";
+    | "projects"
+    | "examples";
 }
 
 const { activeNav } = Astro.props;
@@ -62,11 +63,6 @@ const { activeNav } = Astro.props;
           </svg>
         </button>
         <ul id="menu-items" class="display-none sm:flex">
-          <!-- <li>
-            <a href="/posts/" class={activeNav === "posts" ? "active" : ""}>
-              Posts
-            </a>
-          </li> -->
           <li>
             <a
               href="/projects/"
@@ -90,15 +86,6 @@ const { activeNav } = Astro.props;
               About
             </a>
           </li>
-          <!-- <li>
-            <a
-              href="https://github.com/HendrikPrinsZA"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              GitHub
-            </a>
-          </li> -->
           <li>
             <LinkButton
               href="/search/"

--- a/src/components/examples/ClickCounter.tsx
+++ b/src/components/examples/ClickCounter.tsx
@@ -1,0 +1,20 @@
+import { useState } from "react";
+
+export default function ClickCounter() {
+  const [count, setCount] = useState(0);
+
+  return (
+    <div className="island-card">
+      <p className="island-label">React · client:load</p>
+      <p className="island-desc">Hydrates immediately on page load.</p>
+      <p className="count-display">{count}</p>
+      <button
+        type="button"
+        className="island-btn"
+        onClick={() => setCount(c => c + 1)}
+      >
+        Bump it
+      </button>
+    </div>
+  );
+}

--- a/src/components/examples/ExampleCard.astro
+++ b/src/components/examples/ExampleCard.astro
@@ -1,0 +1,48 @@
+---
+import type { Example } from "@data/examples";
+
+export interface Props {
+  example: Example;
+}
+
+const { example } = Astro.props;
+---
+
+<a href={`/examples/${example.slug}/`} class="example-card group">
+  <span class="emoji" aria-hidden="true">{example.emoji}</span>
+  <h2 class="title">{example.title}</h2>
+  <p class="tagline">{example.tagline}</p>
+  <p class="description">{example.description}</p>
+  <ul class="highlights">
+    {example.highlights.map(highlight => <li>{highlight}</li>)}
+  </ul>
+  <span class="cta">Explore →</span>
+</a>
+
+<style>
+  .example-card {
+    @apply block rounded-xl border border-skin-line bg-skin-card bg-opacity-20 p-6
+    transition-all duration-200 hover:border-skin-accent hover:bg-opacity-40;
+  }
+  .emoji {
+    @apply text-4xl;
+  }
+  .title {
+    @apply mt-3 text-xl font-semibold group-hover:text-skin-accent;
+  }
+  .tagline {
+    @apply mt-1 text-sm italic opacity-70;
+  }
+  .description {
+    @apply mt-3 text-sm leading-relaxed opacity-85;
+  }
+  .highlights {
+    @apply mt-4 flex list-none flex-wrap gap-2 p-0;
+  }
+  .highlights li {
+    @apply rounded-full border border-skin-line px-2.5 py-0.5 text-xs opacity-80;
+  }
+  .cta {
+    @apply mt-5 inline-block text-sm font-medium text-skin-accent;
+  }
+</style>

--- a/src/components/examples/GreetingCard.vue
+++ b/src/components/examples/GreetingCard.vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+import { ref } from "vue";
+
+const greetings = [
+  "Howdy",
+  "Ahoy",
+  "G'day",
+  "Salut",
+  "Hola",
+  "Namaste",
+  "Kia ora",
+];
+const name = ref("Astro");
+const greeting = ref(greetings[0]);
+
+function shuffle() {
+  greeting.value =
+    greetings[Math.floor(Math.random() * greetings.length)] ?? "Hello";
+}
+</script>
+
+<template>
+  <div class="island-card">
+    <p class="island-label">Vue · client:idle</p>
+    <p class="island-desc">Hydrates when the browser is idle.</p>
+    <p class="greeting-text">
+      {{ greeting }}, <strong>{{ name }}</strong
+      >!
+    </p>
+    <label class="name-label">
+      Your name
+      <input v-model="name" type="text" class="name-input" />
+    </label>
+    <button type="button" class="island-btn" @click="shuffle">
+      Shuffle greeting
+    </button>
+  </div>
+</template>
+
+<style scoped>
+.island-card {
+  @apply rounded-xl border border-skin-line bg-skin-card bg-opacity-20 p-5;
+}
+.island-label {
+  @apply text-xs font-semibold uppercase tracking-wider text-skin-accent;
+}
+.island-desc {
+  @apply mt-1 text-sm opacity-70;
+}
+.greeting-text {
+  @apply mt-4 text-2xl font-semibold;
+}
+.name-label {
+  @apply mt-4 block text-sm opacity-80;
+}
+.name-input {
+  @apply mt-1 w-full rounded border border-skin-line bg-skin-fill px-3 py-2 text-skin-base;
+}
+.island-btn {
+  @apply mt-4 rounded-lg border border-skin-accent px-4 py-2 text-sm font-medium
+  text-skin-accent transition-colors hover:bg-skin-accent hover:text-skin-inverted;
+}
+</style>

--- a/src/components/examples/LiveClock.svelte
+++ b/src/components/examples/LiveClock.svelte
@@ -1,0 +1,47 @@
+<script>
+  import { onMount, onDestroy } from "svelte";
+
+  let now = new Date();
+  let interval;
+
+  onMount(() => {
+    interval = setInterval(() => {
+      now = new Date();
+    }, 1000);
+  });
+
+  onDestroy(() => {
+    clearInterval(interval);
+  });
+
+  $: formatted = now.toLocaleString("en-GB", {
+    dateStyle: "full",
+    timeStyle: "long",
+  });
+</script>
+
+<div class="time-card client">
+  <p class="time-label">Client-hydrated</p>
+  <p class="time-value">{formatted}</p>
+  <p class="time-note">
+    Updates every second via a Svelte island with <code>client:load</code>.
+  </p>
+</div>
+
+<style>
+  .time-card {
+    @apply rounded-xl border border-skin-line bg-skin-card bg-opacity-20 p-5;
+  }
+  .time-label {
+    @apply text-xs font-semibold uppercase tracking-wider text-skin-accent;
+  }
+  .time-value {
+    @apply mt-3 font-mono text-lg;
+  }
+  .time-note {
+    @apply mt-2 text-sm opacity-70;
+  }
+  .time-note code {
+    @apply rounded bg-skin-card px-1 text-xs;
+  }
+</style>

--- a/src/components/examples/MoodRing.svelte
+++ b/src/components/examples/MoodRing.svelte
@@ -1,0 +1,58 @@
+<script>
+  let hue = 200;
+  let spinning = false;
+
+  function randomHue() {
+    hue = Math.floor(Math.random() * 360);
+    spinning = true;
+    setTimeout(() => (spinning = false), 600);
+  }
+</script>
+
+<div class="island-card">
+  <p class="island-label">Svelte · client:visible</p>
+  <p class="island-desc">Hydrates when scrolled into view.</p>
+  <button
+    type="button"
+    class="mood-ring"
+    class:spinning
+    style="--ring-hue: {hue}"
+    onclick={randomHue}
+    aria-label="Spin the mood ring"
+  >
+    <span class="ring-inner">{hue}°</span>
+  </button>
+  <p class="ring-hint">Tap the ring to spin a new hue</p>
+</div>
+
+<style>
+  .island-card {
+    @apply rounded-xl border border-skin-line bg-skin-card bg-opacity-20 p-5;
+  }
+  .island-label {
+    @apply text-xs font-semibold uppercase tracking-wider text-skin-accent;
+  }
+  .island-desc {
+    @apply mt-1 text-sm opacity-70;
+  }
+  .mood-ring {
+    @apply mx-auto mt-4 flex h-28 w-28 items-center justify-center rounded-full border-0
+    transition-transform duration-300;
+    background: conic-gradient(
+      hsl(var(--ring-hue) 80% 55%),
+      hsl(calc(var(--ring-hue) + 60) 80% 55%),
+      hsl(calc(var(--ring-hue) + 120) 80% 55%),
+      hsl(var(--ring-hue) 80% 55%)
+    );
+    cursor: pointer;
+  }
+  .mood-ring.spinning {
+    transform: rotate(360deg);
+  }
+  .ring-inner {
+    @apply flex h-16 w-16 items-center justify-center rounded-full bg-skin-fill text-sm font-bold;
+  }
+  .ring-hint {
+    @apply mt-3 text-center text-xs opacity-60;
+  }
+</style>

--- a/src/components/examples/NestedGreeting.astro
+++ b/src/components/examples/NestedGreeting.astro
@@ -1,0 +1,28 @@
+---
+import Panel from "./Panel.astro";
+
+export interface Props {
+  recipient: string;
+}
+
+const { recipient } = Astro.props;
+const builtAt = new Date().toISOString();
+---
+
+<Panel title="Nested Astro component" variant="accent">
+  <p>
+    Hello, <strong>{recipient}</strong>! This entire tree is static HTML — props
+    flow in at build/request time, and no client bundle is needed.
+  </p>
+  <p class="meta">Rendered at <code>{builtAt}</code></p>
+  <Fragment slot="footer"> Pure Astro · zero JavaScript shipped </Fragment>
+</Panel>
+
+<style>
+  .meta {
+    @apply mt-3 text-sm opacity-70;
+  }
+  .meta code {
+    @apply rounded bg-skin-card px-1 text-xs;
+  }
+</style>

--- a/src/components/examples/Panel.astro
+++ b/src/components/examples/Panel.astro
@@ -1,0 +1,40 @@
+---
+export interface Props {
+  title: string;
+  variant?: "default" | "accent";
+}
+
+const { title, variant = "default" } = Astro.props;
+---
+
+<section class:list={["panel", variant === "accent" && "panel--accent"]}>
+  <h3 class="panel-title">{title}</h3>
+  <div class="panel-body">
+    <slot />
+  </div>
+  {
+    Astro.slots.has("footer") && (
+      <footer class="panel-footer">
+        <slot name="footer" />
+      </footer>
+    )
+  }
+</section>
+
+<style>
+  .panel {
+    @apply rounded-xl border border-skin-line bg-skin-card bg-opacity-20 p-5;
+  }
+  .panel--accent {
+    @apply border-skin-accent border-opacity-40;
+  }
+  .panel-title {
+    @apply text-sm font-semibold uppercase tracking-wider text-skin-accent;
+  }
+  .panel-body {
+    @apply mt-3;
+  }
+  .panel-footer {
+    @apply mt-4 border-t border-skin-line pt-3 text-xs opacity-60;
+  }
+</style>

--- a/src/components/examples/QuoteFetcher.svelte
+++ b/src/components/examples/QuoteFetcher.svelte
@@ -1,0 +1,120 @@
+<script>
+  let quote = null;
+  let color = null;
+  let loading = false;
+  let error = null;
+
+  async function fetchQuote() {
+    loading = true;
+    error = null;
+    try {
+      const res = await fetch("/api/examples/quote/");
+      if (!res.ok) throw new Error("Quote fetch failed");
+      quote = await res.json();
+    } catch (e) {
+      error = e instanceof Error ? e.message : "Request failed";
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function fetchColor() {
+    loading = true;
+    error = null;
+    try {
+      const res = await fetch("/api/examples/color/");
+      if (!res.ok) throw new Error("Color fetch failed");
+      color = await res.json();
+    } catch (e) {
+      error = e instanceof Error ? e.message : "Request failed";
+    } finally {
+      loading = false;
+    }
+  }
+</script>
+
+<div class="playground">
+  <div class="actions">
+    <button
+      type="button"
+      class="play-btn"
+      onclick={fetchQuote}
+      disabled={loading}
+    >
+      {loading ? "Fetching…" : "Random quote"}
+    </button>
+    <button
+      type="button"
+      class="play-btn play-btn--alt"
+      onclick={fetchColor}
+      disabled={loading}
+    >
+      {loading ? "Fetching…" : "Random color"}
+    </button>
+  </div>
+
+  {#if error}
+    <p class="error">{error}</p>
+  {/if}
+
+  {#if quote}
+    <blockquote class="quote-result">
+      <p>"{quote.text}"</p>
+      <footer>— {quote.author}</footer>
+    </blockquote>
+  {/if}
+
+  {#if color}
+    <div
+      class="color-result"
+      style="--swatch: {color.hex}; --swatch-name: '{color.name}'"
+    >
+      <div class="swatch" aria-hidden="true"></div>
+      <div class="color-meta">
+        <p class="color-name">{color.name}</p>
+        <p class="color-hex">{color.hex}</p>
+        <p class="color-hsl">hsl({color.h}, {color.s}%, {color.l}%)</p>
+      </div>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .playground {
+    @apply rounded-xl border border-skin-line bg-skin-card bg-opacity-20 p-5;
+  }
+  .actions {
+    @apply flex flex-wrap gap-3;
+  }
+  .play-btn {
+    @apply rounded-lg border border-skin-accent px-4 py-2 text-sm font-medium
+    text-skin-accent transition-colors hover:bg-skin-accent hover:text-skin-inverted
+    disabled:cursor-not-allowed disabled:opacity-50;
+  }
+  .play-btn--alt {
+    @apply border-skin-line text-skin-base hover:border-skin-accent hover:bg-skin-accent;
+  }
+  .error {
+    @apply mt-4 text-sm text-red-500;
+  }
+  .quote-result {
+    @apply mt-5 border-l-4 border-skin-accent pl-4 italic;
+  }
+  .quote-result footer {
+    @apply mt-2 text-sm not-italic opacity-70;
+  }
+  .color-result {
+    @apply mt-5 flex items-center gap-4;
+  }
+  .swatch {
+    @apply h-20 w-20 shrink-0 rounded-xl border border-skin-line;
+    background: var(--swatch);
+  }
+  .color-name {
+    @apply text-lg font-semibold;
+  }
+  .color-hex,
+  .color-hsl {
+    @apply font-mono text-sm opacity-80;
+  }
+</style>

--- a/src/components/examples/ServerTimestamp.astro
+++ b/src/components/examples/ServerTimestamp.astro
@@ -1,0 +1,30 @@
+---
+const serverTime = new Date();
+const formatted = serverTime.toLocaleString("en-GB", {
+  dateStyle: "full",
+  timeStyle: "long",
+});
+---
+
+<div class="time-card server">
+  <p class="time-label">Server-rendered</p>
+  <p class="time-value">{formatted}</p>
+  <p class="time-note">
+    Baked in at request time. No JavaScript required to display this.
+  </p>
+</div>
+
+<style>
+  .time-card {
+    @apply rounded-xl border border-skin-line bg-skin-card bg-opacity-20 p-5;
+  }
+  .time-label {
+    @apply text-xs font-semibold uppercase tracking-wider text-skin-accent;
+  }
+  .time-value {
+    @apply mt-3 font-mono text-lg;
+  }
+  .time-note {
+    @apply mt-2 text-sm opacity-70;
+  }
+</style>

--- a/src/data/examples.ts
+++ b/src/data/examples.ts
@@ -1,0 +1,135 @@
+export type Example = {
+  slug: string;
+  title: string;
+  emoji: string;
+  tagline: string;
+  description: string;
+  highlights: string[];
+};
+
+export const examples: Example[] = [
+  {
+    slug: "islands",
+    title: "Island Party",
+    emoji: "🏝️",
+    tagline: "Three frameworks, one page, zero default JS",
+    description:
+      "React, Svelte, and Vue components coexist on a single page. Each island hydrates only when needed — Astro ships static HTML for everything else.",
+    highlights: [
+      "Islands architecture",
+      "client:load / visible / idle",
+      "Framework mixing",
+    ],
+  },
+  {
+    slug: "time-warp",
+    title: "Time Warp",
+    emoji: "⏳",
+    tagline: "Server time vs. client time",
+    description:
+      "See the difference between a timestamp baked in at request time and a live clock that only runs in the browser.",
+    highlights: [
+      "Server-side rendering",
+      "Selective hydration",
+      "Zero-JS fallback",
+    ],
+  },
+  {
+    slug: "transitions",
+    title: "Cosmic Transitions",
+    emoji: "🌌",
+    tagline: "Morph between pages like magic",
+    description:
+      "Astro View Transitions animate shared elements across routes. Click a cosmic body and watch it glide into its detail view.",
+    highlights: ["View Transitions API", "transition:name", "ClientRouter"],
+  },
+  {
+    slug: "api-playground",
+    title: "API Playground",
+    emoji: "🎲",
+    tagline: "Endpoints you can poke",
+    description:
+      "Hit Astro API routes from the browser and watch JSON flow back. No backend framework required — just endpoints in your pages directory.",
+    highlights: ["API routes", "fetch from islands", "Dynamic responses"],
+  },
+  {
+    slug: "composition",
+    title: "Component Orchestra",
+    emoji: "🎼",
+    tagline: "Slots, props, and nested Astro components",
+    description:
+      "Pure Astro components compose like LEGO. Props flow down, slots flow up, and nothing ships JavaScript unless you ask for it.",
+    highlights: ["Slots & props", "Scoped CSS", "Static by default"],
+  },
+];
+
+export type CosmicBody = {
+  slug: string;
+  name: string;
+  emoji: string;
+  color: string;
+  fact: string;
+  transitionName: string;
+};
+
+export const cosmicBodies: CosmicBody[] = [
+  {
+    slug: "nebula",
+    name: "Nebula",
+    emoji: "🌌",
+    color: "#7c3aed",
+    fact: "Nebulae are stellar nurseries — vast clouds of gas and dust where new stars are born.",
+    transitionName: "cosmic-nebula",
+  },
+  {
+    slug: "pulsar",
+    name: "Pulsar",
+    emoji: "💫",
+    color: "#0ea5e9",
+    fact: "Pulsars are rapidly spinning neutron stars that beam radio waves like a cosmic lighthouse.",
+    transitionName: "cosmic-pulsar",
+  },
+  {
+    slug: "quasar",
+    name: "Quasar",
+    emoji: "✨",
+    color: "#f59e0b",
+    fact: "Quasars are among the brightest objects in the universe, powered by supermassive black holes.",
+    transitionName: "cosmic-quasar",
+  },
+];
+
+export const devQuotes = [
+  {
+    text: "Ship less JavaScript. Your users will thank you.",
+    author: "The Astro team",
+  },
+  {
+    text: "Islands architecture: static HTML with sprinkles of interactivity.",
+    author: "Astro docs",
+  },
+  {
+    text: "The best code is the code you never had to ship.",
+    author: "Every performance engineer",
+  },
+  {
+    text: "Content is king, but delivery is the kingdom.",
+    author: "Web perf wisdom",
+  },
+  {
+    text: "Hydrate only what needs to hydrate. Let the rest be HTML.",
+    author: "Island philosophy",
+  },
+  {
+    text: "View transitions make the web feel native again.",
+    author: "CSS WG fans",
+  },
+  {
+    text: "Astro: the framework that gets out of your way.",
+    author: "Happy developer",
+  },
+  {
+    text: "Server-first, client when necessary. That's the way.",
+    author: "Full-stack minimalism",
+  },
+];

--- a/src/layouts/ExamplesLayout.astro
+++ b/src/layouts/ExamplesLayout.astro
@@ -1,0 +1,37 @@
+---
+import Layout from "@layouts/Layout.astro";
+import Header from "@components/Header.astro";
+import Footer from "@components/Footer.astro";
+import Main from "@layouts/Main.astro";
+import LinkButton from "@components/LinkButton.astro";
+import { SITE } from "@config";
+
+export interface Props {
+  title: string;
+  description?: string;
+  hidePageTitle?: boolean;
+}
+
+const { title, description, hidePageTitle = false } = Astro.props;
+---
+
+<Layout
+  title={`${title} | Examples | ${SITE.title}`}
+  description={description ??
+    "Interactive examples showcasing the power and flexibility of Astro."}
+>
+  <Header activeNav="examples" />
+  <Main pageTitle={hidePageTitle ? undefined : title} pageDesc={description}>
+    <p class="back-link">
+      <LinkButton href="/examples/">← All examples</LinkButton>
+    </p>
+    <slot />
+  </Main>
+  <Footer />
+</Layout>
+
+<style>
+  .back-link {
+    @apply -mt-2 mb-6 not-italic;
+  }
+</style>

--- a/src/pages/api/examples/color.ts
+++ b/src/pages/api/examples/color.ts
@@ -1,0 +1,42 @@
+import type { APIRoute } from "astro";
+
+const colorNames = [
+  "Cosmic Coral",
+  "Nebula Navy",
+  "Stardust Sage",
+  "Supernova Gold",
+  "Aurora Mint",
+  "Pulsar Pink",
+  "Quasar Quartz",
+  "Orbit Orange",
+];
+
+export const GET: APIRoute = () => {
+  const h = Math.floor(Math.random() * 360);
+  const s = 55 + Math.floor(Math.random() * 30);
+  const l = 45 + Math.floor(Math.random() * 20);
+  const name = colorNames[Math.floor(Math.random() * colorNames.length)];
+
+  const hex = hslToHex(h, s, l);
+
+  return new Response(JSON.stringify({ name, hex, h, s, l }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+};
+
+function hslToHex(h: number, s: number, l: number): string {
+  const sNorm = s / 100;
+  const lNorm = l / 100;
+  const a = sNorm * Math.min(lNorm, 1 - lNorm);
+
+  const f = (n: number) => {
+    const k = (n + h / 30) % 12;
+    const color = lNorm - a * Math.max(Math.min(k - 3, 9 - k, 1), -1);
+    return Math.round(255 * color)
+      .toString(16)
+      .padStart(2, "0");
+  };
+
+  return `#${f(0)}${f(8)}${f(4)}`;
+}

--- a/src/pages/api/examples/quote.ts
+++ b/src/pages/api/examples/quote.ts
@@ -1,0 +1,11 @@
+import type { APIRoute } from "astro";
+import { devQuotes } from "@data/examples";
+
+export const GET: APIRoute = () => {
+  const quote = devQuotes[Math.floor(Math.random() * devQuotes.length)];
+
+  return new Response(JSON.stringify(quote), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+};

--- a/src/pages/examples/api-playground.astro
+++ b/src/pages/examples/api-playground.astro
@@ -1,0 +1,58 @@
+---
+import ExamplesLayout from "@layouts/ExamplesLayout.astro";
+import SectionHeading from "@components/SectionHeading.astro";
+import QuoteFetcher from "@components/examples/QuoteFetcher.svelte";
+---
+
+<ExamplesLayout
+  title="API Playground"
+  description="Poke Astro API routes and watch JSON responses flow back."
+>
+  <SectionHeading title="Endpoints in your pages folder" />
+
+  <p class="lede">
+    Astro API routes live alongside your pages. Drop a <code>.ts</code> file in
+    <code>src/pages/api/</code> and export HTTP method handlers — no Express required.
+  </p>
+
+  <QuoteFetcher client:load />
+
+  <div class="endpoints">
+    <h3>Available endpoints</h3>
+    <ul>
+      <li>
+        <a href="/api/examples/quote/" target="_blank">
+          <code>GET /api/examples/quote/</code>
+        </a>
+        — random dev quote
+      </li>
+      <li>
+        <a href="/api/examples/color/" target="_blank">
+          <code>GET /api/examples/color/</code>
+        </a>
+        — random named colour
+      </li>
+    </ul>
+  </div>
+</ExamplesLayout>
+
+<style>
+  .lede {
+    @apply mb-8 text-sm leading-relaxed opacity-85;
+  }
+  .lede code {
+    @apply rounded bg-skin-card px-1 text-xs;
+  }
+  .endpoints {
+    @apply mt-10 rounded-xl border border-skin-line bg-skin-card bg-opacity-10 p-5;
+  }
+  .endpoints h3 {
+    @apply text-sm font-semibold;
+  }
+  .endpoints ul {
+    @apply mt-3 list-none space-y-2 p-0 text-sm;
+  }
+  .endpoints code {
+    @apply font-mono text-skin-accent;
+  }
+</style>

--- a/src/pages/examples/composition.astro
+++ b/src/pages/examples/composition.astro
@@ -1,0 +1,66 @@
+---
+import ExamplesLayout from "@layouts/ExamplesLayout.astro";
+import SectionHeading from "@components/SectionHeading.astro";
+import Panel from "@components/examples/Panel.astro";
+import NestedGreeting from "@components/examples/NestedGreeting.astro";
+
+const instruments = [
+  { name: "Props", role: "Data flows down from parent to child" },
+  { name: "Default slot", role: "Children render where <slot /> is placed" },
+  { name: "Named slots", role: "Footer content via <Fragment slot='footer'>" },
+  { name: "Scoped CSS", role: "Styles stay local to each .astro file" },
+];
+---
+
+<ExamplesLayout
+  title="Component Orchestra"
+  description="Compose Astro components with slots, props, and scoped styles — all static."
+>
+  <SectionHeading title="Pure Astro composition" />
+
+  <p class="lede">
+    Not everything needs a framework. Astro components are the backbone — they
+    compile to HTML with optional scoped styles and zero runtime overhead.
+  </p>
+
+  <div class="orchestra">
+    <Panel title="The conductor" variant="accent">
+      <p>
+        This page is built entirely from <code>.astro</code> files. No islands, no
+        hydration, no client bundle for the layout itself.
+      </p>
+    </Panel>
+
+    <NestedGreeting recipient="visitor" />
+
+    <Panel title="The sections">
+      <ul class="instrument-list">
+        {
+          instruments.map(({ name, role }) => (
+            <li>
+              <strong>{name}</strong> — {role}
+            </li>
+          ))
+        }
+      </ul>
+      <Fragment slot="footer">
+        Each list item was mapped server-side at render time
+      </Fragment>
+    </Panel>
+  </div>
+</ExamplesLayout>
+
+<style>
+  .lede {
+    @apply mb-8 text-sm leading-relaxed opacity-85;
+  }
+  .lede code {
+    @apply rounded bg-skin-card px-1 text-xs;
+  }
+  .orchestra {
+    @apply space-y-5;
+  }
+  .instrument-list {
+    @apply list-none space-y-2 p-0 text-sm;
+  }
+</style>

--- a/src/pages/examples/index.astro
+++ b/src/pages/examples/index.astro
@@ -1,0 +1,57 @@
+---
+import Layout from "@layouts/Layout.astro";
+import Header from "@components/Header.astro";
+import Footer from "@components/Footer.astro";
+import Main from "@layouts/Main.astro";
+import ExampleCard from "@components/examples/ExampleCard.astro";
+import { examples } from "@data/examples";
+import { SITE } from "@config";
+---
+
+<Layout
+  title={`Examples | ${SITE.title}`}
+  description="Interactive examples showcasing the power and flexibility of Astro — islands, view transitions, API routes, and more."
+>
+  <Header activeNav="examples" />
+  <Main
+    pageTitle="Astro Examples"
+    pageDesc="A playground of demos showing why Astro is the framework for content-driven sites that still need sprinkles of interactivity."
+  >
+    <div class="intro">
+      <p>
+        Each example is a self-contained route. View the source on
+        <a
+          href="https://github.com/HendrikPrinsZA/HendrikPrinsZA/tree/main/src/pages/examples"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          GitHub
+        </a>
+        to see how little code it takes.
+      </p>
+    </div>
+
+    <ul class="example-grid">
+      {
+        examples.map(example => (
+          <li>
+            <ExampleCard {example} />
+          </li>
+        ))
+      }
+    </ul>
+  </Main>
+  <Footer />
+</Layout>
+
+<style>
+  .intro {
+    @apply -mt-2 mb-8 text-sm opacity-80;
+  }
+  .example-grid {
+    @apply grid list-none gap-5 p-0 sm:grid-cols-2;
+  }
+  .example-grid > li:last-child:nth-child(odd) {
+    @apply sm:col-span-2 sm:max-w-md sm:justify-self-center sm:w-full;
+  }
+</style>

--- a/src/pages/examples/islands.astro
+++ b/src/pages/examples/islands.astro
@@ -1,0 +1,87 @@
+---
+import ExamplesLayout from "@layouts/ExamplesLayout.astro";
+import SectionHeading from "@components/SectionHeading.astro";
+import ClickCounter from "@components/examples/ClickCounter";
+import MoodRing from "@components/examples/MoodRing.svelte";
+import GreetingCard from "@components/examples/GreetingCard.vue";
+---
+
+<ExamplesLayout
+  title="Island Party"
+  description="React, Svelte, and Vue on one page — each hydrating on its own schedule."
+>
+  <SectionHeading title="Three frameworks, one party" />
+
+  <p class="lede">
+    Astro renders everything as static HTML first. Interactive pieces — called
+    <em>islands</em> — hydrate independently using different
+    <code>client:*</code> directives.
+  </p>
+
+  <div class="island-grid">
+    <ClickCounter client:load />
+    <MoodRing client:visible />
+    <GreetingCard client:idle />
+  </div>
+
+  <div class="legend">
+    <h3>Client directives used</h3>
+    <dl>
+      <div>
+        <dt><code>client:load</code></dt>
+        <dd>Hydrate immediately — good for above-the-fold UI.</dd>
+      </div>
+      <div>
+        <dt><code>client:visible</code></dt>
+        <dd>Hydrate when the element scrolls into view.</dd>
+      </div>
+      <div>
+        <dt><code>client:idle</code></dt>
+        <dd>Hydrate when the browser main thread is free.</dd>
+      </div>
+    </dl>
+  </div>
+</ExamplesLayout>
+
+<style>
+  .lede {
+    @apply mb-8 text-sm leading-relaxed opacity-85;
+  }
+  .lede code {
+    @apply rounded bg-skin-card px-1 text-xs;
+  }
+  .island-grid {
+    @apply grid gap-5 sm:grid-cols-3;
+  }
+  .legend {
+    @apply mt-10 rounded-xl border border-skin-line bg-skin-card bg-opacity-10 p-5;
+  }
+  .legend h3 {
+    @apply text-sm font-semibold;
+  }
+  .legend dl {
+    @apply mt-3 space-y-3;
+  }
+  .legend dt {
+    @apply font-mono text-sm text-skin-accent;
+  }
+  .legend dd {
+    @apply mt-0.5 text-sm opacity-75;
+  }
+  :global(.island-card) {
+    @apply rounded-xl border border-skin-line bg-skin-card bg-opacity-20 p-5;
+  }
+  :global(.island-label) {
+    @apply text-xs font-semibold uppercase tracking-wider text-skin-accent;
+  }
+  :global(.island-desc) {
+    @apply mt-1 text-sm opacity-70;
+  }
+  :global(.count-display) {
+    @apply my-4 text-5xl font-bold tabular-nums;
+  }
+  :global(.island-btn) {
+    @apply rounded-lg border border-skin-accent px-4 py-2 text-sm font-medium
+    text-skin-accent transition-colors hover:bg-skin-accent hover:text-skin-inverted;
+  }
+</style>

--- a/src/pages/examples/time-warp.astro
+++ b/src/pages/examples/time-warp.astro
@@ -1,0 +1,73 @@
+---
+import ExamplesLayout from "@layouts/ExamplesLayout.astro";
+import SectionHeading from "@components/SectionHeading.astro";
+import ServerTimestamp from "@components/examples/ServerTimestamp.astro";
+import LiveClock from "@components/examples/LiveClock.svelte";
+---
+
+<ExamplesLayout
+  title="Time Warp"
+  description="Compare server-rendered timestamps with a live client-side clock."
+>
+  <SectionHeading title="When was this rendered?" />
+
+  <p class="lede">
+    Astro components run on the server. Their output is plain HTML — fast,
+    crawlable, and accessible without JavaScript. Islands add interactivity only
+    where you need it.
+  </p>
+
+  <div class="time-grid">
+    <ServerTimestamp />
+    <LiveClock client:load />
+  </div>
+
+  <div class="comparison">
+    <h3>The difference</h3>
+    <table>
+      <thead>
+        <tr>
+          <th>Approach</th>
+          <th>Updates</th>
+          <th>JavaScript</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Server timestamp</td>
+          <td>Per request / build</td>
+          <td>None</td>
+        </tr>
+        <tr>
+          <td>Live clock island</td>
+          <td>Every second</td>
+          <td>Svelte bundle only</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</ExamplesLayout>
+
+<style>
+  .lede {
+    @apply mb-8 text-sm leading-relaxed opacity-85;
+  }
+  .time-grid {
+    @apply grid gap-5 sm:grid-cols-2;
+  }
+  .comparison {
+    @apply mt-10 rounded-xl border border-skin-line bg-skin-card bg-opacity-10 p-5;
+  }
+  .comparison h3 {
+    @apply text-sm font-semibold;
+  }
+  .comparison table {
+    @apply mt-3 w-full text-sm;
+  }
+  .comparison th {
+    @apply border-b border-skin-line pb-2 text-left font-medium opacity-70;
+  }
+  .comparison td {
+    @apply border-b border-skin-line border-opacity-50 py-2;
+  }
+</style>

--- a/src/pages/examples/transitions/[slug].astro
+++ b/src/pages/examples/transitions/[slug].astro
@@ -1,0 +1,47 @@
+---
+import ExamplesLayout from "@layouts/ExamplesLayout.astro";
+import { cosmicBodies } from "@data/examples";
+
+export function getStaticPaths() {
+  return cosmicBodies.map(body => ({
+    params: { slug: body.slug },
+    props: { body },
+  }));
+}
+
+const { body } = Astro.props;
+---
+
+<ExamplesLayout title={body.name} description={body.fact} hidePageTitle>
+  <article class="cosmic-detail" style={`--body-color: ${body.color}`}>
+    <span class="cosmic-emoji" transition:name={body.transitionName}>
+      {body.emoji}
+    </span>
+    <h1 class="cosmic-title" transition:name={`${body.transitionName}-label`}>
+      {body.name}
+    </h1>
+    <p class="cosmic-fact">{body.fact}</p>
+    <p class="cosmic-hint">
+      Hit back — the emoji and title will morph back to the grid.
+    </p>
+  </article>
+</ExamplesLayout>
+
+<style>
+  .cosmic-detail {
+    @apply flex flex-col items-center py-8 text-center;
+  }
+  .cosmic-emoji {
+    @apply text-8xl;
+  }
+  .cosmic-title {
+    @apply mt-6 text-3xl font-bold;
+    color: var(--body-color);
+  }
+  .cosmic-fact {
+    @apply mt-4 max-w-md text-base leading-relaxed opacity-85;
+  }
+  .cosmic-hint {
+    @apply mt-8 text-sm italic opacity-60;
+  }
+</style>

--- a/src/pages/examples/transitions/index.astro
+++ b/src/pages/examples/transitions/index.astro
@@ -1,0 +1,65 @@
+---
+import ExamplesLayout from "@layouts/ExamplesLayout.astro";
+import SectionHeading from "@components/SectionHeading.astro";
+import { cosmicBodies } from "@data/examples";
+---
+
+<ExamplesLayout
+  title="Cosmic Transitions"
+  description="Click a cosmic body and watch it morph into its detail view via Astro View Transitions."
+>
+  <SectionHeading title="Pick a cosmic body" />
+
+  <p class="lede">
+    Shared elements with matching <code>transition:name</code> attributes animate
+    smoothly between routes. Astro's <code>ClientRouter</code> handles the rest.
+  </p>
+
+  <ul class="cosmic-grid">
+    {
+      cosmicBodies.map(body => (
+        <li>
+          <a
+            href={`/examples/transitions/${body.slug}/`}
+            class="cosmic-card"
+            style={`--body-color: ${body.color}`}
+          >
+            <span class="cosmic-emoji" transition:name={body.transitionName}>
+              {body.emoji}
+            </span>
+            <span
+              class="cosmic-name"
+              transition:name={`${body.transitionName}-label`}
+            >
+              {body.name}
+            </span>
+          </a>
+        </li>
+      ))
+    }
+  </ul>
+</ExamplesLayout>
+
+<style>
+  .lede {
+    @apply mb-8 text-sm leading-relaxed opacity-85;
+  }
+  .lede code {
+    @apply rounded bg-skin-card px-1 text-xs;
+  }
+  .cosmic-grid {
+    @apply grid list-none gap-4 p-0 sm:grid-cols-3;
+  }
+  .cosmic-card {
+    @apply flex flex-col items-center rounded-xl border border-skin-line
+    bg-skin-card bg-opacity-20 p-8 text-center transition-colors
+    hover:border-skin-accent hover:bg-opacity-40;
+  }
+  .cosmic-emoji {
+    @apply text-6xl;
+    view-transition-name: var(--vt-name, none);
+  }
+  .cosmic-name {
+    @apply mt-4 text-lg font-semibold;
+  }
+</style>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a new Examples section showcasing Astro islands, view transitions, API routes, and component composition; also migrates the image generator to ESM with safer error handling and updates the `generate:images` script.

- **New Features**
  - New Examples index and layout, linked from the header.
  - Islands page mixing React `ClickCounter`, Svelte `MoodRing`, and Vue `GreetingCard` with `client:load`, `client:visible`, and `client:idle`.
  - Time Warp page comparing server `ServerTimestamp` with a client `LiveClock`.
  - View Transitions demo with a grid and detail routes using shared `transition:name`.
  - API Playground with `GET /api/examples/quote/` and `GET /api/examples/color/`, driven by a Svelte `QuoteFetcher`.
  - Component composition demo using Astro-only `Panel` and `NestedGreeting`.

- **Refactors**
  - Convert `bin/generate/index` to ESM (`index.mjs`) and update `generate:images` in `package.json`.
  - Add graceful fallback in image generation: create `.error.svg` via `text-to-svg` on download failures.

<sup>Written for commit d100484655051f7a38a56e0520af018a96b2d6f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HendrikPrinsZA/HendrikPrinsZA/pull/159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

